### PR TITLE
Remove SSH key from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v1
-        with:
-          private-key: ${{ secrets.SSH_KEY }}
-          known-hosts: github.com
-
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
The SSH key is no longer needed, as we aren't using Git modules anymore.